### PR TITLE
Reece/MoreMetadata

### DIFF
--- a/app/app.go
+++ b/app/app.go
@@ -128,7 +128,7 @@ const appName = "TokenApp"
 
 // We pull these out so we can set them with LDFLAGS in the Makefile
 var (
-	NodeDir      = ".tokenfactory"
+	NodeDir      = ".wasmd"
 	Bech32Prefix = "wasm"
 
 	// If EnabledSpecificProposals is "", and this is "true", then enable all x/wasm proposals.

--- a/app/app.go
+++ b/app/app.go
@@ -128,7 +128,7 @@ const appName = "TokenApp"
 
 // We pull these out so we can set them with LDFLAGS in the Makefile
 var (
-	NodeDir      = ".wasmd"
+	NodeDir      = ".tokenfactory"
 	Bech32Prefix = "wasm"
 
 	// If EnabledSpecificProposals is "", and this is "true", then enable all x/wasm proposals.

--- a/scripts/test_metadata.sh
+++ b/scripts/test_metadata.sh
@@ -22,13 +22,12 @@ BINARY query tokenfactory denoms-from-creator wasm1hj5fveer5cjtn4wd6wstzugjfdxzl
 
 # set the metadata for it
 BINARY tx tokenfactory modify-metadata $DENOM "ticker" "some desc https://www.com" 6 $FLAGS
-BINARY tx tokenfactory modify-metadata $DENOM "ticker" "updated desc https://google.com" 18 $FLAGS
+
 BINARY q bank denom-metadata --denom $DENOM --node http://localhost:26657
 
 # fails
 BINARY tx tokenfactory modify-metadata $DENOM "ticker" "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa" 18 $FLAGS
 BINARY tx tokenfactory modify-metadata $DENOM "ticker" "<html>" 18 $FLAGS
-BINARY tx tokenfactory modify-metadata $DENOM "ticker" "\n\n\n\n\ntest\n\n\n" 18 $FLAGS
 BINARY tx tokenfactory modify-metadata $DENOM "ticker" "alert('test')" 18 $FLAGS
 BINARY tx tokenfactory modify-metadata $DENOM2 "JUNO" "desc" 6 $FLAGS
 BINARY tx tokenfactory modify-metadata $DENOM2 "!" "desc" 6 $FLAGS

--- a/scripts/test_metadata.sh
+++ b/scripts/test_metadata.sh
@@ -1,0 +1,28 @@
+export KEY="tf1" # wasm1hj5fveer5cjtn4wd6wstzugjfdxzl0xpvsr89g
+export CHAIN_ID=${CHAIN_ID:-"tf-1"}
+export KEYRING=${KEYRING:-"test"}
+export HOME_DIR=$(eval echo "${HOME_DIR:-"~/.tf1/"}")
+export BINARY=${BINARY:-toked}
+
+alias BINARY="$BINARY --home=$HOME_DIR"
+
+FLAGS="--from $KEY --keyring-backend=test --gas=1000000 --node http://localhost:26657 --chain-id tf-1 --yes"
+
+DENOM=test
+BINARY tx tokenfactory create-denom $DENOM $FLAGS
+BINARY tx tokenfactory create-denom "$DENOM"2 $FLAGS
+
+BINARY query tokenfactory denoms-from-creator wasm1hj5fveer5cjtn4wd6wstzugjfdxzl0xpvsr89g --node http://localhost:26657
+
+# set the metadata for it
+BINARY tx tokenfactory modify-metadata factory/wasm1hj5fveer5cjtn4wd6wstzugjfdxzl0xpvsr89g/$DENOM "udenom" "TICKER" "some desc https://www.com" 6 $FLAGS
+
+# fails
+BINARY tx tokenfactory modify-metadata factory/wasm1hj5fveer5cjtn4wd6wstzugjfdxzl0xpvsr89g/$DENOM2 "ujuno" "TICKER" "desc" 6 $FLAGS
+BINARY tx tokenfactory modify-metadata factory/wasm1hj5fveer5cjtn4wd6wstzugjfdxzl0xpvsr89g/$DENOM2 "juno" "TICKER" "desc" 6 $FLAGS
+BINARY tx tokenfactory modify-metadata factory/wasm1hj5fveer5cjtn4wd6wstzugjfdxzl0xpvsr89g/$DENOM2 "ibc/test" "TICKER" "desc" 1 $FLAGS
+BINARY tx tokenfactory modify-metadata factory/wasm1hj5fveer5cjtn4wd6wstzugjfdxzl0xpvsr89g/$DENOM2 "factory/" "TICKER" "desc" 1 $FLAGS
+
+BINARY q bank denom-metadata --node http://localhost:26657
+
+BINARY tx tokenfactory mint 100factory/wasm1hj5fveer5cjtn4wd6wstzugjfdxzl0xpvsr89g/$DENOM $FLAGS

--- a/scripts/test_metadata.sh
+++ b/scripts/test_metadata.sh
@@ -7,26 +7,39 @@ export BINARY=${BINARY:-toked}
 alias BINARY="$BINARY --home=$HOME_DIR"
 
 FLAGS="--from $KEY --keyring-backend=test --gas=1000000 --node http://localhost:26657 --chain-id tf-1 --yes --broadcast-mode=block"
+FLAGS2="--from feeacc --keyring-backend=test --gas=1000000 --node http://localhost:26657 --chain-id tf-1 --yes --broadcast-mode=block"
 
-DENOM=test
-DENOM2=test2
-BINARY tx tokenfactory create-denom $DENOM $FLAGS
-BINARY tx tokenfactory create-denom $DENOM2 $FLAGS
+# toked keys list --keyring-backend test --home $HOME_DIR
+DENOM=factory/wasm1hj5fveer5cjtn4wd6wstzugjfdxzl0xpvsr89g/test
+DENOM2=factory/wasm1hj5fveer5cjtn4wd6wstzugjfdxzl0xpvsr89g/test2
+DENOM_NOT_MINE=factory/wasm1efd63aw40lxf3n4mhf7dzhjkr453axursysrvp/notmine
+
+BINARY tx tokenfactory create-denom test $FLAGS
+BINARY tx tokenfactory create-denom test2 $FLAGS
+BINARY tx tokenfactory create-denom notmine $FLAGS2
 
 BINARY query tokenfactory denoms-from-creator wasm1hj5fveer5cjtn4wd6wstzugjfdxzl0xpvsr89g --node http://localhost:26657
 
 # set the metadata for it
-BINARY tx tokenfactory modify-metadata factory/wasm1hj5fveer5cjtn4wd6wstzugjfdxzl0xpvsr89g/$DENOM "udenom" "TICKER" "some desc https://www.com" 6 $FLAGS
+BINARY tx tokenfactory modify-metadata $DENOM "ticker" "some desc https://www.com" 6 $FLAGS
+BINARY tx tokenfactory modify-metadata $DENOM "ticker" "" 18 $FLAGS
+BINARY q bank denom-metadata --denom $DENOM --node http://localhost:26657
 
 # fails
-BINARY tx tokenfactory modify-metadata factory/wasm1hj5fveer5cjtn4wd6wstzugjfdxzl0xpvsr89g/$DENOM2 "ujuno" "TICKER" "desc" 6 $FLAGS
-BINARY tx tokenfactory modify-metadata factory/wasm1hj5fveer5cjtn4wd6wstzugjfdxzl0xpvsr89g/$DENOM2 "juno" "TICKER" "desc" 6 $FLAGS
-BINARY tx tokenfactory modify-metadata factory/wasm1hj5fveer5cjtn4wd6wstzugjfdxzl0xpvsr89g/$DENOM2 "good" "UJUNO" "desc" 6 $FLAGS
-BINARY tx tokenfactory modify-metadata factory/wasm1hj5fveer5cjtn4wd6wstzugjfdxzl0xpvsr89g/$DENOM2 "ibc/test" "TICKER" "desc" 1 $FLAGS
-BINARY tx tokenfactory modify-metadata factory/wasm1hj5fveer5cjtn4wd6wstzugjfdxzl0xpvsr89g/$DENOM2 "factory/" "TICKER" "desc" 1 $FLAGS
+BINARY tx tokenfactory modify-metadata $DENOM2 "JUNO" "desc" 6 $FLAGS
+BINARY tx tokenfactory modify-metadata $DENOM2 "!" "desc" 6 $FLAGS
+BINARY tx tokenfactory modify-metadata $DENOM2 "LJUNO" "desc" 6 $FLAGS
+BINARY tx tokenfactory modify-metadata $DENOM2 "LUJUNO" "desc" 6 $FLAGS
+BINARY tx tokenfactory modify-metadata $DENOM2 "sla/sh" "desc" 6 $FLAGS
+BINARY tx tokenfactory modify-metadata $DENOM2 "thelengthiswaytoolonghere" "desc" 1 $FLAGS
+BINARY tx tokenfactory modify-metadata $DENOM2 "" "desc" 1 $FLAGS
+BINARY tx tokenfactory modify-metadata $DENOM2 "expont" "desc" 19 $FLAGS
+
+# can't edit a token we don't own (tries to edit feeacc's address)
+BINARY tx tokenfactory modify-metadata $DENOM_NOT_MINE "notmy" "desc" 1 $FLAGS
 
 # query data
-BINARY q bank denom-metadata --denom factory/wasm1hj5fveer5cjtn4wd6wstzugjfdxzl0xpvsr89g/$DENOM --node http://localhost:26657
-BINARY q bank denom-metadata --denom factory/wasm1hj5fveer5cjtn4wd6wstzugjfdxzl0xpvsr89g/$DENOM2 --node http://localhost:26657
 
-BINARY tx tokenfactory mint 100factory/wasm1hj5fveer5cjtn4wd6wstzugjfdxzl0xpvsr89g/$DENOM $FLAGS
+BINARY q bank denom-metadata --denom $DENOM2 --node http://localhost:26657
+
+BINARY tx tokenfactory mint 100$DENOM $FLAGS

--- a/scripts/test_metadata.sh
+++ b/scripts/test_metadata.sh
@@ -21,6 +21,7 @@ BINARY tx tokenfactory modify-metadata factory/wasm1hj5fveer5cjtn4wd6wstzugjfdxz
 # fails
 BINARY tx tokenfactory modify-metadata factory/wasm1hj5fveer5cjtn4wd6wstzugjfdxzl0xpvsr89g/$DENOM2 "ujuno" "TICKER" "desc" 6 $FLAGS
 BINARY tx tokenfactory modify-metadata factory/wasm1hj5fveer5cjtn4wd6wstzugjfdxzl0xpvsr89g/$DENOM2 "juno" "TICKER" "desc" 6 $FLAGS
+BINARY tx tokenfactory modify-metadata factory/wasm1hj5fveer5cjtn4wd6wstzugjfdxzl0xpvsr89g/$DENOM2 "good" "UJUNO" "desc" 6 $FLAGS
 BINARY tx tokenfactory modify-metadata factory/wasm1hj5fveer5cjtn4wd6wstzugjfdxzl0xpvsr89g/$DENOM2 "ibc/test" "TICKER" "desc" 1 $FLAGS
 BINARY tx tokenfactory modify-metadata factory/wasm1hj5fveer5cjtn4wd6wstzugjfdxzl0xpvsr89g/$DENOM2 "factory/" "TICKER" "desc" 1 $FLAGS
 

--- a/scripts/test_metadata.sh
+++ b/scripts/test_metadata.sh
@@ -22,10 +22,14 @@ BINARY query tokenfactory denoms-from-creator wasm1hj5fveer5cjtn4wd6wstzugjfdxzl
 
 # set the metadata for it
 BINARY tx tokenfactory modify-metadata $DENOM "ticker" "some desc https://www.com" 6 $FLAGS
-BINARY tx tokenfactory modify-metadata $DENOM "ticker" "" 18 $FLAGS
+BINARY tx tokenfactory modify-metadata $DENOM "ticker" "updated desc https://google.com" 18 $FLAGS
 BINARY q bank denom-metadata --denom $DENOM --node http://localhost:26657
 
 # fails
+BINARY tx tokenfactory modify-metadata $DENOM "ticker" "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa" 18 $FLAGS
+BINARY tx tokenfactory modify-metadata $DENOM "ticker" "<html>" 18 $FLAGS
+BINARY tx tokenfactory modify-metadata $DENOM "ticker" "\n\n\n\n\ntest\n\n\n" 18 $FLAGS
+BINARY tx tokenfactory modify-metadata $DENOM "ticker" "alert('test')" 18 $FLAGS
 BINARY tx tokenfactory modify-metadata $DENOM2 "JUNO" "desc" 6 $FLAGS
 BINARY tx tokenfactory modify-metadata $DENOM2 "!" "desc" 6 $FLAGS
 BINARY tx tokenfactory modify-metadata $DENOM2 "LJUNO" "desc" 6 $FLAGS
@@ -40,6 +44,6 @@ BINARY tx tokenfactory modify-metadata $DENOM_NOT_MINE "notmy" "desc" 1 $FLAGS
 
 # query data
 
-BINARY q bank denom-metadata --denom $DENOM2 --node http://localhost:26657
+BINARY q bank denom-metadata --denom $DENOM --node http://localhost:26657
 
 BINARY tx tokenfactory mint 100$DENOM $FLAGS

--- a/scripts/test_metadata.sh
+++ b/scripts/test_metadata.sh
@@ -6,11 +6,12 @@ export BINARY=${BINARY:-toked}
 
 alias BINARY="$BINARY --home=$HOME_DIR"
 
-FLAGS="--from $KEY --keyring-backend=test --gas=1000000 --node http://localhost:26657 --chain-id tf-1 --yes"
+FLAGS="--from $KEY --keyring-backend=test --gas=1000000 --node http://localhost:26657 --chain-id tf-1 --yes --broadcast-mode=block"
 
 DENOM=test
+DENOM2=test2
 BINARY tx tokenfactory create-denom $DENOM $FLAGS
-BINARY tx tokenfactory create-denom "$DENOM"2 $FLAGS
+BINARY tx tokenfactory create-denom $DENOM2 $FLAGS
 
 BINARY query tokenfactory denoms-from-creator wasm1hj5fveer5cjtn4wd6wstzugjfdxzl0xpvsr89g --node http://localhost:26657
 
@@ -23,6 +24,8 @@ BINARY tx tokenfactory modify-metadata factory/wasm1hj5fveer5cjtn4wd6wstzugjfdxz
 BINARY tx tokenfactory modify-metadata factory/wasm1hj5fveer5cjtn4wd6wstzugjfdxzl0xpvsr89g/$DENOM2 "ibc/test" "TICKER" "desc" 1 $FLAGS
 BINARY tx tokenfactory modify-metadata factory/wasm1hj5fveer5cjtn4wd6wstzugjfdxzl0xpvsr89g/$DENOM2 "factory/" "TICKER" "desc" 1 $FLAGS
 
-BINARY q bank denom-metadata --node http://localhost:26657
+# query data
+BINARY q bank denom-metadata --denom factory/wasm1hj5fveer5cjtn4wd6wstzugjfdxzl0xpvsr89g/$DENOM --node http://localhost:26657
+BINARY q bank denom-metadata --denom factory/wasm1hj5fveer5cjtn4wd6wstzugjfdxzl0xpvsr89g/$DENOM2 --node http://localhost:26657
 
 BINARY tx tokenfactory mint 100factory/wasm1hj5fveer5cjtn4wd6wstzugjfdxzl0xpvsr89g/$DENOM $FLAGS

--- a/scripts/test_node.sh
+++ b/scripts/test_node.sh
@@ -1,0 +1,120 @@
+#!/bin/bash
+# Run this script to quickly install, setup, and run the current version of juno without docker.
+#
+# Example:
+# CHAIN_ID="tf-1" HOME_DIR="~/.tf1/" TIMEOUT_COMMIT="500ms" CLEAN=true sh scripts/test_node.sh
+# CHAIN_ID="tf-2" HOME_DIR="~/.tf2/" CLEAN=true RPC=36657 REST=2317 PROFF=6061 P2P=36656 GRPC=8090 GRPC_WEB=8091 ROSETTA=8081 TIMEOUT_COMMIT="500ms" sh scripts/test_node.sh
+
+export KEY="tf1"
+export CHAIN_ID=${CHAIN_ID:-"tf-1"}
+export MONIKER="localtf"
+export KEYALGO="secp256k1"
+export KEYRING=${KEYRING:-"test"}
+export HOME_DIR=$(eval echo "${HOME_DIR:-"~/.tokenfactory/"}")
+
+export BINARY=${BINARY:-toked}
+export CLEAN=${CLEAN:-"false"}
+
+export RPC=${RPC:-"26657"}
+export REST=${REST:-"1317"}
+export PROFF=${PROFF:-"6060"}
+export P2P=${P2P:-"26656"}
+export GRPC=${GRPC:-"9090"}
+export GRPC_WEB=${GRPC_WEB:-"9091"}
+export ROSETTA=${ROSETTA:-"8080"}
+export TIMEOUT_COMMIT=${TIMEOUT_COMMIT:-"5s"}
+
+toked config keyring-backend $KEYRING
+toked config chain-id $CHAIN_ID
+
+alias BINARY="$BINARY --home=$HOME_DIR"
+
+# Debugging
+echo "CHAIN_ID=$CHAIN_ID, HOME_DIR=$HOME_DIR, CLEAN=$CLEAN, RPC=$RPC, REST=$REST, PROFF=$PROFF, P2P=$P2P, GRPC=$GRPC, GRPC_WEB=$GRPC_WEB, ROSETTA=$ROSETTA, TIMEOUT_COMMIT=$TIMEOUT_COMMIT"
+
+command -v toked > /dev/null 2>&1 || { echo >&2 "toked command not found. Ensure this is setup / properly installed in your GOPATH."; exit 1; }
+command -v jq > /dev/null 2>&1 || { echo >&2 "jq not installed. More info: https://stedolan.github.io/jq/download/"; exit 1; }
+
+from_scratch () {
+  # Fresh install on current branch
+  make install
+
+  # remove existing daemon.
+  rm -rf $HOME_DIR && echo "Removed $HOME_DIR"  
+  
+  # juno1efd63aw40lxf3n4mhf7dzhjkr453axurv2zdzk
+  echo "decorate bright ozone fork gallery riot bus exhaust worth way bone indoor calm squirrel merry zero scheme cotton until shop any excess stage laundry" | BINARY keys add $KEY --keyring-backend $KEYRING --algo $KEYALGO --recover
+  # juno1hj5fveer5cjtn4wd6wstzugjfdxzl0xps73ftl
+  echo "wealth flavor believe regret funny network recall kiss grape useless pepper cram hint member few certain unveil rather brick bargain curious require crowd raise" | BINARY keys add feeacc --keyring-backend $KEYRING --algo $KEYALGO --recover
+  
+  BINARY init $MONIKER --chain-id $CHAIN_ID
+
+  # Function updates the config based on a jq argument as a string
+  update_test_genesis () {
+    # update_test_genesis '.consensus_params["block"]["max_gas"]="100000000"'
+    cat $HOME_DIR/config/genesis.json | jq "$1" > $HOME_DIR/config/tmp_genesis.json && mv $HOME_DIR/config/tmp_genesis.json $HOME_DIR/config/genesis.json
+  }
+
+  # Set gas limit in genesis
+  update_test_genesis '.consensus_params["block"]["max_gas"]="100000000"'
+  update_test_genesis '.app_state["gov"]["voting_params"]["voting_period"]="15s"'
+
+  update_test_genesis '.app_state["staking"]["params"]["bond_denom"]="ujuno"'  
+  update_test_genesis '.app_state["bank"]["params"]["send_enabled"]=[{"denom": "ujuno","enabled": true}]'
+  # update_test_genesis '.app_state["staking"]["params"]["min_commission_rate"]="0.100000000000000000"' # sdk 46 only   
+
+  update_test_genesis '.app_state["mint"]["params"]["mint_denom"]="ujuno"'  
+  update_test_genesis '.app_state["gov"]["deposit_params"]["min_deposit"]=[{"denom": "ujuno","amount": "1000000"}]'
+  update_test_genesis '.app_state["crisis"]["constant_fee"]={"denom": "ujuno","amount": "1000"}'  
+
+  update_test_genesis '.app_state["tokenfactory"]["params"]["denom_creation_fee"]=[{"denom":"ujuno","amount":"100"}]'
+
+  update_test_genesis '.app_state["feeshare"]["params"]["allowed_denoms"]=["ujuno"]'
+
+  # Allocate genesis accounts
+  BINARY add-genesis-account $KEY 10000000ujuno,1000utest --keyring-backend $KEYRING
+  BINARY add-genesis-account feeacc 1000000ujuno,1000utest --keyring-backend $KEYRING
+
+  BINARY gentx $KEY 1000000ujuno --keyring-backend $KEYRING --chain-id $CHAIN_ID
+
+  # Collect genesis tx
+  BINARY collect-gentxs
+
+  # Run this to ensure junorything worked and that the genesis file is setup correctly
+  BINARY validate-genesis
+}
+
+# check if CLEAN is not set to false
+if [ "$CLEAN" != "false" ]; then
+  echo "Starting from a clean state"
+  from_scratch
+fi
+
+echo "Starting node..."
+
+# Opens the RPC endpoint to outside connections
+sed -i 's/laddr = "tcp:\/\/127.0.0.1:26657"/c\laddr = "tcp:\/\/0.0.0.0:'$RPC'"/g' $HOME_DIR/config/config.toml
+sed -i 's/cors_allowed_origins = \[\]/cors_allowed_origins = \["\*"\]/g' $HOME_DIR/config/config.toml
+
+# REST endpoint
+sed -i 's/address = "tcp:\/\/0.0.0.0:1317"/address = "tcp:\/\/0.0.0.0:'$REST'"/g' $HOME_DIR/config/app.toml
+sed -i 's/enable = false/enable = true/g' $HOME_DIR/config/app.toml
+
+# replace pprof_laddr = "localhost:6060" binding
+sed -i 's/pprof_laddr = "localhost:6060"/pprof_laddr = "localhost:'$PROFF_LADDER'"/g' $HOME_DIR/config/config.toml
+
+# change p2p addr laddr = "tcp://0.0.0.0:26656"
+sed -i 's/laddr = "tcp:\/\/0.0.0.0:26656"/laddr = "tcp:\/\/0.0.0.0:'$P2P'"/g' $HOME_DIR/config/config.toml
+
+# GRPC
+sed -i 's/address = "0.0.0.0:9090"/address = "0.0.0.0:'$GRPC'"/g' $HOME_DIR/config/app.toml
+sed -i 's/address = "0.0.0.0:9091"/address = "0.0.0.0:'$GRPC_WEB'"/g' $HOME_DIR/config/app.toml
+
+# Rosetta Api
+sed -i 's/address = ":8080"/address = "0.0.0.0:'$ROSETTA'"/g' $HOME_DIR/config/app.toml
+
+# faster blocks
+sed -i 's/timeout_commit = "5s"/timeout_commit = "'$TIMEOUT_COMMIT'"/g' $HOME_DIR/config/config.toml
+
+# Start the node with 0 gas fees
+BINARY start --pruning=nothing  --minimum-gas-prices=0ujuno --rpc.laddr="tcp://0.0.0.0:$RPC"

--- a/x/tokenfactory/client/cli/tx.go
+++ b/x/tokenfactory/client/cli/tx.go
@@ -16,8 +16,7 @@ import (
 	banktypes "github.com/cosmos/cosmos-sdk/x/bank/types"
 )
 
-var DENIED_DENOMS = [2]string{"ujuno", "juno"}
-var DENIED_STARTS_WITH_DENOMS = [2]string{"ibc/", "factory/"}
+var DeniedDenoms = [4]string{"ujuno", "juno", "ibc/", "factory/"}
 
 // GetTxCmd returns the transaction commands for this module
 func GetTxCmd() *cobra.Command {
@@ -210,15 +209,9 @@ func NewModifyDenomMetadataCmd() *cobra.Command {
 
 			fullDenom, prettyName, ticker, desc := args[0], args[1], args[2], args[3]
 
-			for _, chainDenom := range DENIED_DENOMS {
-				if strings.ToLower(ticker) == chainDenom || strings.ToLower(prettyName) == chainDenom {
-					return fmt.Errorf("denied ticker symbol: %s", chainDenom)
-				}
-
-			}
-			for _, prefix := range DENIED_STARTS_WITH_DENOMS {
+			for _, prefix := range DeniedDenoms {
 				if strings.HasPrefix(strings.ToLower(ticker), prefix) || strings.HasPrefix(strings.ToLower(prettyName), prefix) {
-					return fmt.Errorf("denied ticker symbol: %s", prefix)
+					return fmt.Errorf("ticker or prefix symbol which starts with: %s is not allowed", prefix)
 				}
 			}
 

--- a/x/tokenfactory/client/cli/tx.go
+++ b/x/tokenfactory/client/cli/tx.go
@@ -239,7 +239,7 @@ func NewModifyDenomMetadataCmd() *cobra.Command {
 				return fmt.Errorf("description cannot be greater than 255 characters: %d", len(desc))
 			}
 
-			deniedCharList := "@#$^*<>;()\\n\\t"
+			deniedCharList := "@#$^*<>;()"
 			if strings.ContainsAny(desc, deniedCharList) {
 				return fmt.Errorf("desc cannot contain special characters: %s", deniedCharList)
 			}

--- a/x/tokenfactory/client/cli/tx.go
+++ b/x/tokenfactory/client/cli/tx.go
@@ -216,6 +216,7 @@ func NewModifyDenomMetadataCmd() *cobra.Command {
 				return fmt.Errorf("denom must start with factory/")
 			}
 
+			// Ticker Checks
 			for _, prefix := range DeniedDenoms {
 				if strings.Contains(strings.ToLower(ticker), prefix) {
 					return fmt.Errorf("ticker contains a denied word: %s and is not allowed", prefix)
@@ -233,6 +234,17 @@ func NewModifyDenomMetadataCmd() *cobra.Command {
 				return fmt.Errorf("ticker cannot be empty")
 			}
 
+			// Description Length Checks
+			if len(desc) > 255 {
+				return fmt.Errorf("description cannot be greater than 255 characters: %d", len(desc))
+			}
+
+			deniedCharList := "@#$^*<>;()\\n\\t"
+			if strings.ContainsAny(desc, deniedCharList) {
+				return fmt.Errorf("desc cannot contain special characters: %s", deniedCharList)
+			}
+
+			// Exponent Checks
 			exponent, err := strconv.ParseUint(args[3], 10, 32)
 			if err != nil {
 				return err


### PR DESCRIPTION
<https://twitter.com/noahsaso/status/1629319268226732032?s=20>

Adds more metadata such as the token description, ticker, and exponent. Then a webapp can query it to properly

### Set Constraints
- Max Ticker Length: 6
- Max Exponent: 18
- Must be a factory/ denom AND you must be the admin of it to change
- no ticker can contain "juno" (any case) or a slash "/"
- Description limited to 255 characters
- Description blocks symbols `@#$^*<>;()`
- exponent must be positive

### Questions
- Should we allow the ticker to contain juno? just not start with it? (for LSD's using native tokens)

---

`BINARY tx tokenfactory modify-metadata $DENOM "ticker" "updated desc www.google.com" 18 $FLAGS`

Then a webapp can query the data with
`BINARY q bank denom-metadata --denom $DENOM --node http://localhost:26657`

```
metadata:
  base: factory/wasm1hj5fveer5cjtn4wd6wstzugjfdxzl0xpvsr89g/test
  denom_units:
  - aliases:
    - TICKER
    denom: factory/wasm1hj5fveer5cjtn4wd6wstzugjfdxzl0xpvsr89g/test
    exponent: 0
  - aliases:
    - factory/wasm1hj5fveer5cjtn4wd6wstzugjfdxzl0xpvsr89g/test
    denom: TICKER
    exponent: 18
  description: updated desc www.google.com
  display: factory/wasm1hj5fveer5cjtn4wd6wstzugjfdxzl0xpvsr89g/test
  name: factory/wasm1hj5fveer5cjtn4wd6wstzugjfdxzl0xpvsr89g/test
  symbol: TICKER
  ```